### PR TITLE
fix missing files

### DIFF
--- a/cdq.gemspec
+++ b/cdq.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   files.concat(Dir.glob('lib/**/*.rb'))
   files.concat(Dir.glob('motion/**/*.rb'))
   files.concat(Dir.glob('templates/**/*.rb'))
+  files.concat(Dir.glob('vendor/**/*.rb'))
   gem.files = files
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "cdq"


### PR DESCRIPTION
add vendor directory in cdq.gemspec

```
Generating Data Model HelloApp
   Loading schemas/0001_initial.rb
   Writing resources/HelloApp.xcdatamodeld/0001 initial.xcdatamodel/contents
     Build ./build/iPhoneSimulator-7.0-Development
     Build /Users/toshiwo/apps/HelloApp/vendor/bundle/gems/cdq-0.1.3/lib/../vendor/cdq/ext
rake aborted!
No such file or directory @ dir_chdir - /Users/toshiwo/apps/HelloApp/vendor/bundle/gems/cdq-0.1.3/lib/../vendor/cdq/ext/
```
