### PR TITLE
Adds destroy_all and destroy_all! to managed objects.

### DIFF
--- a/motion/managed_object.rb
+++ b/motion/managed_object.rb
@@ -72,6 +72,17 @@ class CDQManagedObject < CoreDataQueryManagedObjectBase
       super || cdq.respond_to?(name)
     end
 
+    def destroy_all
+      self.all.array.each do |instance|
+        instance.destroy
+      end
+    end
+
+    def destroy_all!
+      destroy_all
+      cdq.save
+    end
+
   end
 
   # Register this object for destruction with the current context.  Will not

--- a/spec/cdq/managed_object_spec.rb
+++ b/spec/cdq/managed_object_spec.rb
@@ -42,6 +42,16 @@ module CDQ
       Writer.all.array.should == []
     end
 
+    it "can destroy all instances of itself" do
+      cdq(Writer).create(name: 'Dean Kuntz')
+      cdq(Writer).create(name: 'Stephen King')
+      cdq(Writer).create(name: 'Tom Clancy')
+      Writer.count.should == 3
+
+      Writer.destroy_all!
+      Writer.count.should == 0
+    end
+
     it "works with entities that do not have a specific implementation class" do
       rh = cdq('Publisher').create(name: "Random House")
       cdq('Publisher').where(:name).include("Random").first.should == rh


### PR DESCRIPTION
With passing test.

Makes it easier to reset back to zero by calling `YourModel.destroy_all!`.

`96 specifications (167 requirements), 0 failures, 0 errors`
