### PR TITLE
Fix for relationship add/removes not being persisted

### DIFF
--- a/motion/cdq/relationship_query.rb
+++ b/motion/cdq/relationship_query.rb
@@ -6,7 +6,12 @@ module CDQ
     def initialize(owner, name, set = nil, opts = {})
       @owner = owner
       @relationship_name = name
-      @set = set || @owner.send(name)
+      @set = set
+      if @owner.ordered_set?(name)
+        @set ||= @owner.mutableOrderedSetValueForKey(name)
+      else
+        @set ||= @owner.mutableSetValueForKey(name)
+      end
       relationship = owner.entity.relationshipsByName[name]
       @inverse_rel = relationship.inverseRelationship
       entity_description = relationship.destinationEntity
@@ -30,11 +35,6 @@ module CDQ
     # Add an existing object to the relationship
     #
     def add(obj)
-      if @inverse_rel.isToMany
-        obj.send(@inverse_rel.name).addObject(@owner)
-      else
-        obj.send("#{@inverse_rel.name}=", @owner)
-      end
       @set.addObject obj
     end
     alias_method :<<, :add

--- a/motion/managed_object.rb
+++ b/motion/managed_object.rb
@@ -96,13 +96,28 @@ class CDQManagedObject < CoreDataQueryManagedObjectBase
     description
   end
 
+  def ordered_set?(name)
+    # isOrdered is returning 0/1 instead of documented BOOL
+    ordered = entity.relationshipsByName[name].isOrdered
+    return true if ordered == true || ordered == 1
+    return false if ordered == false || ordered == 0
+  end
+
+  def set_to_extend(name)
+    if ordered_set?(name)
+      mutableOrderedSetValueForKey(name)
+    else
+      mutableSetValueForKey(name)
+    end
+  end
+
   protected
 
   # Called from method that's dynamically added from
   # +[CoreDataManagedObjectBase defineRelationshipMethod:]
   def relationshipByName(name)
     willAccessValueForKey(name)
-    set = CDQRelationshipQuery.extend_set(primitiveValueForKey(name), self, name)
+    set = CDQRelationshipQuery.extend_set(set_to_extend(name), self, name)
     didAccessValueForKey(name)
     set
   end

--- a/spec/cdq/relationship_query_spec.rb
+++ b/spec/cdq/relationship_query_spec.rb
@@ -57,6 +57,30 @@ module CDQ
       ram.spouses.first.writers.count.should == 1
     end
 
+    it "can remove a relationship and persist it" do
+      ram = Writer.create(name: "Ram Das")
+      ram.spouses.add cdq('Spouse').create(name: "First Spouse")
+      ram.spouses << cdq('Spouse').create
+      ram.spouses.count.should == 2
+      cdq.save(always_wait: true)
+
+      cdq.contexts.reset!; ram = nil; cdq.setup
+      ram = Writer.where(:name).eq("Ram Das").first
+      ram.spouses.count.should == 2
+      first_spouse = ram.spouses.first
+      first_spouse.writers.count.should == 1
+      ram.spouses.remove(first_spouse)
+      ram.spouses.count.should == 1
+      first_spouse.writers.count.should == 0
+      cdq.save(always_wait: true)
+
+      cdq.contexts.reset!; ram = nil; cdq.setup
+      ram = Writer.where(:name).eq("Ram Das").first
+      ram.spouses.count.should == 1
+      ex_spouse = cdq('Spouse').where(:name).eq("First Spouse").first
+      ex_spouse.writers.count.should == 0
+    end
+
     it "can remove objects from the relationship" do
       article = Article.create(title: "thing", body: "bank")
       cdq.save


### PR DESCRIPTION
I was running into a problem where relationships were not being persisted reliably.  Every thing looked good in the running app but it was not saving the relationships to sqlite.  I finally found this in the docs.

https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/CoreData/Articles/cdUsingMOs.html#//apple_ref/doc/uid/TP40001803-CJBDBHCB
Under the "To-many relationships" section

> It is important to understand the difference between the values returned by the dot accessor and by mutableSetValueForKey:. mutableSetValueForKey: returns a mutable proxy object. If you mutate its contents, it will emit the appropriate key-value observing (KVO) change notifications for the relationship. The dot accessor simply returns a set. If you manipulate the set as shown in this code fragment:
> 
> `[aDepartment.employees addObject:newEmployee]; // do not do this!`
> then KVO change notifications are not emitted and the inverse relationship is not updated correctly.
> 
> Recall that the dot simply invokes the accessor method, so for the same reasons:
> 
> `[[aDepartment employees] addObject:newEmployee]; // do not do this, either!`

I am still new to cdq and core data so there is probably a better way to do this, but I added a spec and a fix that seems to be working for me.
