### PR TITLE
change the default root name. Use CFBundleExecutable instead of CFBundleDisplayName.

### DIFF
--- a/motion/cdq/config.rb
+++ b/motion/cdq/config.rb
@@ -39,7 +39,7 @@ module CDQ
         h = {}
       end
 
-      @name = h['name'] || h[:name] || NSBundle.mainBundle.objectForInfoDictionaryKey("CFBundleDisplayName")
+      @name = h['name'] || h[:name] || NSBundle.mainBundle.objectForInfoDictionaryKey("CFBundleExecutable")
       @database_dir = search_directory_for h['database_dir'] || h[:database_dir]
       @database_name = h['database_name'] || h[:database_name] || name
       @model_name = h['model_name'] || h[:model_name] || name

--- a/spec/cdq/config_spec.rb
+++ b/spec/cdq/config_spec.rb
@@ -5,7 +5,7 @@ module CDQ
   describe "CDQ Config" do
 
     before do
-      @bundle_name = NSBundle.mainBundle.objectForInfoDictionaryKey("CFBundleDisplayName")
+      @bundle_name = NSBundle.mainBundle.objectForInfoDictionaryKey("CFBundleExecutable")
     end
 
     it "sets default values when no config file present" do


### PR DESCRIPTION
CFBundleDisplayName is localizable.
If I added a localized file, the root name is localized.
Then the app will be missing the database file.

I think CFBundleExecutable is a proper key.
If you know a more proper key, please change it.
