### PR TITLE
Fixes issue #35

### DIFF
--- a/lib/cdq.rb
+++ b/lib/cdq.rb
@@ -4,6 +4,7 @@ unless defined?(Motion::Project::App)
 end
 
 require 'ruby-xcdm'
+require 'motion-yaml'
 
 ENV['COLUMNS'] ||= `tput cols`.strip
 


### PR DESCRIPTION
Require `motion-yaml` in the main cdq lib file instead of just the `Rakefile`.

Fixes issue #35
