### PR TITLE
Update README with clearer LIKE predicate examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ list.
   Author.where(:name).eq('Shakespeare')
   Author.where(:publish_count).gt(10)
   Author.where(name: 'Shakespeare', publish_count: 15)
-  Author.where("name LIKE '%@'", '*kesp*')
-  Author.where("name LIKE '%@'", 'Shakespear?')
+  Author.where("name LIKE %@", '*kesp*')
+  Author.where("name LIKE %@", 'Shakespear?')
 ```
 
 ### Sorts, Limits and Offsets


### PR DESCRIPTION
LIKE in Core Data takes "*" or "?" as per http://stackoverflow.com/questions/2740933/nspredicate-that-is-the-equivalent-of-sqls-like, not %
