### PR TITLE
add test for multi threading.

### DIFF
--- a/motion/cdq/context.rb
+++ b/motion/cdq/context.rb
@@ -69,12 +69,12 @@ module CDQ
     # will be set to the previous head context.  If a block is supplied, the new context
     # will exist for the duration of the block and then the previous state will be restore_managerd.
     #
-    def new(concurrency_type, parent = nil, &block)
+    def new(concurrency_type, &block)
       @has_been_set_up = true
       
       context = NSManagedObjectContext.alloc.initWithConcurrencyType(concurrency_type)
-      if parent || current
-        context.parentContext = parent || current
+      if current
+        context.parentContext = current
       else
         if @store_manager.invalid?
           raise "store coordinator not found. Cannot create the first context without one."

--- a/spec/thread_spec.rb
+++ b/spec/thread_spec.rb
@@ -1,5 +1,4 @@
 describe "multi threading" do
-  tests UIViewController
 
   before do
     class << self
@@ -11,18 +10,14 @@ describe "multi threading" do
     Author.count.should == 0
     
     parent = cdq.contexts.current
-    Dispatch::Queue.concurrent.async do
-      cdq.contexts.new(NSConfinementConcurrencyType, parent) do
-        context = cdq.contexts.current
-        @parent = context.parentContext
+    Dispatch::Queue.concurrent.sync do
+      cdq.contexts.push(parent)
+      cdq.contexts.new(NSConfinementConcurrencyType) do
         Author.create(name:"George")
         @result = cdq.save
       end
     end
-    
-    wait 0.3 do
-      Author.count.should == 1
-    end
+    Author.count.should == 1
   end
 
 end


### PR DESCRIPTION
It seems to need to pass a parent context between threads.

The current context is nil when initializing context in the gcd concurrent queue.
Then it create a store in the gcd concurrent queue and rise exception or etc..

Adding a parent argument seems to work.
`def new(concurrency_type, parent = nil, &block)`
