### PR TITLE
Use class name when inside of a module. Fixes #50

### DIFF
--- a/motion/cdq.rb
+++ b/motion/cdq.rb
@@ -53,8 +53,10 @@ module CDQ
       if obj.isSubclassOfClass(NSManagedObject)
         entities = NSDictionary.dictionaryWithDictionary(
           @@base_object.models.current.entitiesByName)
+        entity_name = obj.name.split("::").last
+        # NOTE attempt to look up the entity
         entity_description =
-          entities[obj.name] ||
+          entities[entity_name] ||
           entities[obj.ancestors[1].name]
         if entity_description.nil?
           raise "Cannot find an entity named #{obj.name}"


### PR DESCRIPTION
Does this make sense for a fix for #50? I think its fair to assume that the class name should be used for the entity, since it looks like colons are banned in entity names?
