### PR TITLE
Implement app group containers for Extensions

### DIFF
--- a/motion/cdq/config.rb
+++ b/motion/cdq/config.rb
@@ -69,7 +69,6 @@ module CDQ
       end
 
       path = File.join(dir, database_name + '.sqlite')
-      puts path
       NSURL.fileURLWithPath(path)
     end
 

--- a/motion/cdq/config.rb
+++ b/motion/cdq/config.rb
@@ -13,7 +13,7 @@ module CDQ
   #   [database_name]             The root name for the database file (relative to the database_dir)
   #   [model_name]                The root name for the model file (relative to the bundle directory)
   #   [app_group_id]              The app group id set in iTunes member center (group.com.mycompany.myapp)
-  #   [app_group_container_uuid]  WORKAROUND: The app group's UUID for iOS Simulator 6.1 which doesn't return an app group container path from the id
+  #   [app_group_container_uuid]  WORKAROUND: The app group's UUID for iOS Simulator 8.1 which doesn't return an app group container path from the id
   #   [icloud]                    If it's true, CDQ works with iCloud.
   #   [icloud_container]          Set id of iCloud container if you use iCloud. If it's nil, use first container listed in the com.apple.developer.ubiquity-container-identifiers entitlement array.
   #

--- a/motion/cdq/config.rb
+++ b/motion/cdq/config.rb
@@ -8,12 +8,14 @@ module CDQ
   # model file.  This file is named <tt>cdq.yml</tt> and must be found at the
   # root of your resources directory.  It supports the following top-level keys:
   #
-  #   [name]              The root name for both database and model
-  #   [database_dir]      The root name for the database directory (NSDocumentDirectory or NSApplicationSupportDirectory)
-  #   [database_name]     The root name for the database file (relative to the database_dir)
-  #   [model_name]        The root name for the model file (relative to the bundle directory)
-  #   [icloud]            If it's true, CDQ works with iCloud.
-  #   [icloud_container]  Set id of iCloud container if you use iCloud. If it's nil, use first container listed in the com.apple.developer.ubiquity-container-identifiers entitlement array.
+  #   [name]                      The root name for both database and model
+  #   [database_dir]              The root name for the database directory (NSDocumentDirectory or NSApplicationSupportDirectory)
+  #   [database_name]             The root name for the database file (relative to the database_dir)
+  #   [model_name]                The root name for the model file (relative to the bundle directory)
+  #   [app_group_id]              The app group id set in iTunes member center (group.com.mycompany.myapp)
+  #   [app_group_container_uuid]  WORKAROUND: The app group's UUID for iOS Simulator 6.1 which doesn't return an app group container path from the id
+  #   [icloud]                    If it's true, CDQ works with iCloud.
+  #   [icloud_container]          Set id of iCloud container if you use iCloud. If it's nil, use first container listed in the com.apple.developer.ubiquity-container-identifiers entitlement array.
   #
   # Using the config file is not necessary.  If you do not include it, the bundle display name
   # will be used.  For most people with a new app, this is what you want to do, especially if
@@ -24,7 +26,7 @@ module CDQ
   #
   class CDQConfig
 
-    attr_reader :config_file, :database_name, :database_dir, :model_name, :name, :icloud, :icloud_container
+    attr_reader :config_file, :database_name, :database_dir, :model_name, :name, :icloud, :icloud_container, :app_group_id, :app_group_container_uuid
 
     def initialize(config_file)
       h = nil
@@ -46,6 +48,8 @@ module CDQ
       @database_dir = search_directory_for h['database_dir'] || h[:database_dir]
       @database_name = h['database_name'] || h[:database_name] || name
       @model_name = h['model_name'] || h[:model_name] || name
+      @app_group_id = h['app_group_id'] || h[:app_group_id]
+      @app_group_container_uuid = h['app_group_container_uuid'] || h[:app_group_container_uuid]
       @icloud = begin
         case h['icloud'] || h[:icloud]
         when true, 1
@@ -56,15 +60,32 @@ module CDQ
       end
       @icloud_container = h['icloud_container'] || h[:icloud_container]
     end
-
+    
     def database_url
-      dir = NSSearchPathForDirectoriesInDomains(database_dir, NSUserDomainMask, true).last
+      if app_group_id.nil?
+        dir = NSSearchPathForDirectoriesInDomains(database_dir, NSUserDomainMask, true).last
+      else
+        dir = app_group_container
+      end
+
       path = File.join(dir, database_name + '.sqlite')
+      puts path
       NSURL.fileURLWithPath(path)
     end
 
     def model_url
       NSBundle.mainBundle.URLForResource(model_name, withExtension: "momd");
+    end
+
+    def app_group_container
+      if (UIDevice.currentDevice.model =~ /simulator/i).nil?  # device
+        dir = NSFileManager.defaultManager.containerURLForSecurityApplicationGroupIdentifier(app_group_id).path
+      elsif ! app_group_container_uuid.nil?   # simulator with app group uuid workaround
+        dev_container = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true).last.stringByDeletingLastPathComponent.stringByDeletingLastPathComponent.stringByDeletingLastPathComponent.stringByDeletingLastPathComponent
+        dir = dev_container.stringByAppendingPathComponent("Shared").stringByAppendingPathComponent("AppGroup").stringByAppendingPathComponent(app_group_container_uuid)
+      else   # simulator no workaround, fallback to default dir
+        dir = NSSearchPathForDirectoriesInDomains(database_dir, NSUserDomainMask, true).last
+      end
     end
 
     def self.default


### PR DESCRIPTION
When setting an app_group_id in the cdq.yml file, the database url will now point to the shared app container. This allows for app extensions to access the same database as their parent app.

Additionally includes a workaround for use on iOS Simulator v8.1 which doesn't seem to behave correctly, as discussed here: https://groups.google.com/forum/#!topic/rubymotion/qDsNSf8NtXM Sorry that this part isn't the most elegant code in the world!