### PR TITLE
Add calculation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,16 @@ Here are some examples.  **See the [cheat sheet](https://github.com/infinitered/
   Author.where(:name).contains("Emily").and(cdq(:pub_count).gt(100).or.lt(10))
 ```
 
+### Calculations
+
+```ruby
+  Author.sum(:fee)
+  Author.average(:fee)
+  Author.min(:fee)
+  Author.max(:fee)
+  Author.where(:name).eq("Emily").sum(:fee)
+```
+
 ### Fetching
 
 Like ActiveRecord, CDQ will not run a fetch until you actually request specific

--- a/motion/cdq/targeted_query.rb
+++ b/motion/cdq/targeted_query.rb
@@ -89,7 +89,7 @@ module CDQ #:nodoc:
       array.each(*args, &block)
     end
 
-    # Calculates the sum of values on a given column.
+    # Calculation method based on core data aggregate functions.
     def calculate(operation, column_name)
       raise("No context has been set.  Probably need to run cdq.setup") unless context
       raise("Cannot find attribute #{column_name} while calculating #{operation}") unless @entity_description.attributesByName[column_name.to_s]

--- a/spec/cdq/calculation_spec.rb
+++ b/spec/cdq/calculation_spec.rb
@@ -1,0 +1,58 @@
+module CDQ
+  describe "CDQ Calculation Methods" do
+
+    before do
+      CDQ.cdq.setup
+
+      class << self
+        include CDQ
+      end
+      
+      @fees = [1.0, 2.0, 3.0]
+      @author_foo = Author.create(name: 'foo', fee: @fees[0])
+      Author.create(name: 'foo', fee: @fees[1])
+      Author.create(name: 'bar', fee: @fees[2])
+      
+      @lengths = [1, 2, 3, 4]
+      @author_foo.articles.create(title: 'foo', body: 'bar', length: @lengths[0])
+      @author_foo.articles.create(title: 'foo', body: 'bar', length: @lengths[1])
+      Article.create(title: 'foo', body: 'bar', length: @lengths[2])
+      Article.create(title: 'foo', body: 'bar', length: @lengths[3])
+      cdq.save(always_wait: true)
+    end
+
+    after do
+      CDQ.cdq.reset!
+    end
+
+    it "can calculate sum of float values" do
+      Author.sum(:fee).should == @fees.inject(:+)
+    end
+
+    it "can calculate average of float values" do
+      Author.average(:fee).should == (@fees.inject(:+).to_f / @fees.size)
+    end
+
+    it "can calculate min of float values" do
+      Author.min(:fee).should == @fees[0]
+      Author.minimum(:fee).should == @fees[0]
+    end
+
+    it "can calculate max of float values" do
+      Author.max(:fee).should == @fees[2]
+      Author.maximum(:fee).should == @fees[2]
+    end
+
+    it "can calculate sum of integer values" do
+      Article.sum(:length).should == @lengths.inject(:+)
+    end
+
+    it "can do calculation with chained query" do
+      Author.where(:name).eq('foo').calculate(:sum, :fee).should == @fees[0..1].inject(:+)
+    end
+
+    it "can do calculation on relations" do
+      @author_foo.articles.calculate(:sum, :length).should == @lengths[0..1].inject(:+)
+    end
+  end
+end


### PR DESCRIPTION
Add calculation method based on core data aggregate functions. Borrow ideas from ActiveRecord and this issue discussion:
#47 
Sample usage:
```ruby
  Author.sum(:fee)
  Author.average(:fee)
  Author.min(:fee)
  Author.max(:fee)
  Author.where(:name).eq("Emily").sum(:fee)
```