### PR TITLE
Extend configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,10 @@ before_install:
   - sudo chown -R travis ~/Library/RubyMotion
   - mkdir -p ~/Library/RubyMotion/build
   - sudo motion update
+gemfile:
+  - Gemfile
+script:
+  - bundle install
+  - bundle exec rake clean
+  - bundle exec rake spec
+  - bundle exec rake spec platform=osx

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 $:.unshift("/Library/RubyMotion/lib")
-require 'motion/project/template/ios'
+
+platform = ENV.fetch('platform', 'ios')
+require "motion/project/template/#{platform}"
 
 require 'bundler'
 require 'bundler/gem_tasks'

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -1,6 +1,12 @@
 class AppDelegate
   include CDQ
 
+  # OS X entry point
+  def applicationDidFinishLaunching(notification)
+    cdq.setup
+  end
+
+  # iOS entry point
   def application(application, didFinishLaunchingWithOptions:launchOptions)
     cdq.setup
     true

--- a/motion/cdq/config.rb
+++ b/motion/cdq/config.rb
@@ -95,6 +95,9 @@ module CDQ
         end
     end
 
+    def self.default_config=(config_obj)
+      @default = config_obj
+    end
 
     private
 

--- a/motion/cdq/object.rb
+++ b/motion/cdq/object.rb
@@ -24,7 +24,26 @@ module CDQ
       @@store_manager = nil
     end
 
+    # Save any data and close down the contexts and store manager.
+    # You should be able create a new CDQConfig object and run setup 
+    # again to attach to a different database.  However, you need to be sure
+    # that all activity is finished, and that any exisitng model instances
+    # have been deallocated.
+    #------------------------------------------------------------------------------
+    def close
+      save
+      @@context_manager.reset! if @@context_manager
+      @@context_manager        = nil
+      @@store_manager          = nil
+      CDQConfig.default_config = nil
+    end
+
+    # You can now pass in a CDQConfig object, which will be used instead of the
+    # one loaded from the cdq.yml file.  However, the model file is loaded during
+    # the loading of the code - so it can only be overridden using the cdq.yml.
+    #------------------------------------------------------------------------------
     def setup(opts = {})
+      CDQConfig.default_config = opts[:config] || nil
       if opts[:context]
         contexts.push(opts[:context])
         return true

--- a/spec/cdq/config_spec.rb
+++ b/spec/cdq/config_spec.rb
@@ -124,7 +124,7 @@ module CDQ
     it "constructs model_url" do
       config = CDQConfig.new(nil)
       config.model_url.class.should == NSURL
-      config.model_url.path.should =~ %r{#{@bundle_name}_spec.app/#{@bundle_name}.momd$}
+      config.model_url.path.should =~ %r{#{@bundle_name}_spec.app/.*#{@bundle_name}.momd$}
     end
 
     def yaml_to_file(file, hash)

--- a/spec/cdq/object_spec.rb
+++ b/spec/cdq/object_spec.rb
@@ -53,6 +53,22 @@ module CDQ
       cdq.setup(context: context)
       cdq.contexts.current.should == context
     end
+
+    it "can open different database without deleting the previous one" do
+      org_database_url = CDQConfig.default.database_url.path
+      File.exist?(org_database_url).should == true
+      cdq.close
+
+      config = CDQConfig.new(name: "foo")
+      File.exist?(config.database_url.path).should == false
+      
+      cdq.setup(config: config)
+
+      CDQConfig.default.should == config
+      File.exist?(config.database_url.path).should == true
+      File.exist?(org_database_url).should == true
+    end
+
   end
 
 end


### PR DESCRIPTION
This fixes #93 by enhancing the `cdq.setup` to accept a CDQConfig object.  It also allows the specs to be run against OS X using `platform=osx rake spec` 