### PR TITLE
TargetedQuery: scopes clashing spec to show a clashing

### DIFF
--- a/app/test_models.rb
+++ b/app/test_models.rb
@@ -1,7 +1,9 @@
 class Author < CDQManagedObject
+  scope :clashing, where(:name).eq('eecummings')
 end
 
 class Article < CDQManagedObject
+  scope :clashing, sort_by(:publishedAt)
   scope :all_published, where(:published).eq(true)
   scope :with_title, where(:title).ne(nil).sort_by(:title, order: :descending)
   scope :published_since { |date| where(:publishedAt).ge(date) }

--- a/spec/cdq/targeted_query_spec.rb
+++ b/spec/cdq/targeted_query_spec.rb
@@ -144,16 +144,10 @@ module CDQ
     end
 
     it "can create a scope with the same name for two entities without clashing" do
-      article = cdq('Article')
       a = article.create(publishedAt: Time.local(2001))
-      author = @tq
 
-      article.scope :past, cdq(:publishedAt).lt(Time.now)
-      author.scope :past, cdq(:name).eq('eecummings')
-
-      article.past.array.should == [a]
-      author.past.array.should == [@eecummings]
-
+      Article.clashing.array.should == [a]
+      Author.clashing.array.should == [@eecummings]
     end
   end
 end


### PR DESCRIPTION
I've changed scope clashing spec to show that in fact clashing is happening when you are using classes.

````
NSInvalidArgumentException: keypath publishedAt not found in entity <NSSQLEntity Author id=2>
````