### PR TITLE
Bug: scoped defined in CDQManagedObject subclass are clashing

### DIFF
--- a/app/test_models.rb
+++ b/app/test_models.rb
@@ -2,6 +2,7 @@ class Author < CDQManagedObject
 end
 
 class Article < CDQManagedObject
+  scope :clashing, where(:title).eq('war & peace')
   scope :all_published, where(:published).eq(true)
   scope :with_title, where(:title).ne(nil).sort_by(:title, order: :descending)
   scope :published_since { |date| where(:publishedAt).ge(date) }
@@ -11,6 +12,7 @@ class Citation < CDQManagedObject
 end
 
 class Writer < CDQManagedObject
+  scope :clashing, where(:fee).eq(42.0)
 end
 
 class Timestamp < CDQManagedObject

--- a/motion/managed_object.rb
+++ b/motion/managed_object.rb
@@ -42,11 +42,11 @@ class CDQManagedObject < CoreDataQueryManagedObjectBase
     def scope(name, query = nil, &block)
       cdq.scope(name, query, &block)
       if query
-        self.class.send(:define_method, name) do
+        define_method(name) do
           where(query)
         end
       else
-        self.class.send(:define_method, name) do |*args|
+        define_method(name) do |*args|
           where(block.call(*args))
         end
       end

--- a/spec/cdq/managed_object_spec.rb
+++ b/spec/cdq/managed_object_spec.rb
@@ -133,6 +133,9 @@ module CDQ
 
         Article.clashing.array.should == [article]
         Writer.clashing.array.should == [writer]
+
+        cdq('Article').clashing.array.should == [atricle]
+        cdq('Writer').clashing.array.should == [writer]
       end
 
       describe "CDQ Managed Object dynamic scopes" do

--- a/spec/cdq/managed_object_spec.rb
+++ b/spec/cdq/managed_object_spec.rb
@@ -128,10 +128,10 @@ module CDQ
       end
 
       it "are not clashing" do
-        atricle = Article.create(title: 'war & peace')
+        article = Article.create(title: 'war & peace')
         writer = Writer.create(name: 'rbachman', fee: 42.0)
 
-        Article.clashing.array.should == [atricle]
+        Article.clashing.array.should == [article]
         Writer.clashing.array.should == [writer]
       end
 

--- a/spec/cdq/managed_object_spec.rb
+++ b/spec/cdq/managed_object_spec.rb
@@ -134,7 +134,7 @@ module CDQ
         Article.clashing.array.should == [article]
         Writer.clashing.array.should == [writer]
 
-        cdq('Article').clashing.array.should == [atricle]
+        cdq('Article').clashing.array.should == [article]
         cdq('Writer').clashing.array.should == [writer]
       end
 

--- a/spec/cdq/managed_object_spec.rb
+++ b/spec/cdq/managed_object_spec.rb
@@ -127,6 +127,14 @@ module CDQ
         cdq('Writer').edgaralpoe.array.should == [@poe]
       end
 
+      it "are not clashing" do
+        atricle = Article.create(title: 'war & peace')
+        writer = Writer.create(name: 'rbachman', fee: 42.0)
+
+        Article.clashing.array.should == [atricle]
+        Writer.clashing.array.should == [writer]
+      end
+
       describe "CDQ Managed Object dynamic scopes" do
 
         class Writer


### PR DESCRIPTION
Description: Scopes defined in the different ``CDQManagedObject`` subclasses are overriding each other.

Problem: ``self.class`` in the scope of ``class << self`` will be a ``Class`` itself. So when we're are defining  scopes with same name on the different ``CDQManagedObject`` subclasses the will override each other. Also, scope methods will leak as class methods for all classes.

Solution: use simple ``define_method`` instead, since we are already in the scope of the Class instance metaclass.

