### PR TITLE
fix Illformed requirement error which causes with RubyGem 2.4.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     cdq (1.0.3)
       motion-yaml
-      ruby-xcdm (~> 0.0, >= 0.0.9)
+      ruby-xcdm (>= 0.0.9)
 
 GEM
   remote: https://rubygems.org/

--- a/cdq.gemspec
+++ b/cdq.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "cdq"
   gem.require_paths = ["lib"]
-  gem.add_runtime_dependency 'ruby-xcdm', '~> 0.0', '>= 0.0.9'
+  gem.add_runtime_dependency 'ruby-xcdm', '>= 0.0.9'
   gem.add_runtime_dependency 'motion-yaml'
   gem.executables << 'cdq'
 


### PR DESCRIPTION
If RubyGem 2.4.8 was installed, `rake spec` causes error as following.
This patch should fix error.

```
$ gem -v
2.4.8

$ rake spec
/Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/requirement.rb:100:in `parse': Illformed requirement [#<Gem::Requirement:0x007fd88aa56f30 @requirements=[["~>", #<Gem::Version "0.0">], [">=", #<Gem::Version "0.0.9">]]>] (Gem::Requirement::BadRequirementError)
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/requirement.rb:141:in `block in concat'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/requirement.rb:141:in `map'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/requirement.rb:141:in `concat'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set.rb:117:in `gem'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set/gem_dependency_api.rb:233:in `block in add_dependencies'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set/gem_dependency_api.rb:232:in `each'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set/gem_dependency_api.rb:232:in `add_dependencies'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set/gem_dependency_api.rb:602:in `gemspec'
	from /Users/watson/tmp/cdq/Gemfile:3:in `load'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set/gem_dependency_api.rb:278:in `instance_eval'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set/gem_dependency_api.rb:278:in `load'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/request_set.rb:289:in `load_gemdeps'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems.rb:1055:in `use_gemdeps'
	from /Users/watson/.rbenv/versions/2.2.2/lib/ruby/site_ruby/2.2.0/rubygems.rb:1244:in `<top (required)>'
	from <internal:gem_prelude>:1:in `require'
	from <internal:gem_prelude>:1:in `<compiled>'
```