### PR TITLE
ManagedObject: use `define_singleton_method` instead of `define_method`

### DIFF
--- a/motion/managed_object.rb
+++ b/motion/managed_object.rb
@@ -42,11 +42,11 @@ class CDQManagedObject < CoreDataQueryManagedObjectBase
     def scope(name, query = nil, &block)
       cdq.scope(name, query, &block)
       if query
-        define_method(name) do
+        define_singleton_method(name) do
           where(query)
         end
       else
-        define_method(name) do |*args|
+        define_singleton_method(name) do |*args|
           where(block.call(*args))
         end
       end

--- a/spec/cdq/managed_object_spec.rb
+++ b/spec/cdq/managed_object_spec.rb
@@ -138,6 +138,10 @@ module CDQ
         cdq('Writer').clashing.array.should == [writer]
       end
 
+      it "are available to respond_to?" do
+        Writer.respond_to?(:by_name).should == true
+      end
+
       describe "CDQ Managed Object dynamic scopes" do
 
         class Writer


### PR DESCRIPTION
Ooopsie, I've messes up a bit with #100. It should be `define_singleton_method`, not the `define_method`. But for some reason method is callable, but it's not in the `methods` list and it isn't checkable by `respond_to?`. 

Spec added for this case.