### PR TITLE
Require motion-yaml in library.

### DIFF
--- a/lib/cdq.rb
+++ b/lib/cdq.rb
@@ -5,6 +5,7 @@ end
 
 require 'ruby-xcdm'
 require 'yaml'
+require 'motion-yaml'
 
 ENV['COLUMNS'] ||= `tput cols`.strip
 


### PR DESCRIPTION
Fixes crash on device:

```
<Warning>: config.rb:38:in `block in initialize:': uninitialized constant CDQ::CDQConfig::YAML (NameError)
<Error>: *** Terminating app due to uncaught exception 'NameError', reason: 'config.rb:38:in `block in initialize:': uninitialized constant CDQ::CDQConfig::YAML (NameError)
```