### PR TITLE
reset! needs to delete all sqlite files

### DIFF
--- a/motion/cdq/store.rb
+++ b/motion/cdq/store.rb
@@ -24,7 +24,10 @@ module CDQ
     end
 
     def reset!
+      path = @config.database_url.absoluteString
       NSFileManager.defaultManager.removeItemAtURL(@config.database_url, error: nil)
+      NSFileManager.defaultManager.removeItemAtURL(NSURL.URLWithString("#{path}-shm"), error: nil)
+      NSFileManager.defaultManager.removeItemAtURL(NSURL.URLWithString("#{path}-wal"), error: nil)
     end
 
     def invalid?


### PR DESCRIPTION
When using the WAL journaling mode (the default), 3 files are created (.sqlite, .sqlite-shm, .sqlite-wal).  All three should be deleted in `reset!`.  This fixes getting a `SQLite error code:522, 'not an error'` and `error: -addPersistentStoreWithType:SQLite configuration`

http://stackoverflow.com/questions/18277092/persistentstorecoordinator-sqlite-error-code522-not-an-error