### PR TITLE
Relationship queries: easier to scope/chain

### DIFF
--- a/motion/cdq/relationship_query.rb
+++ b/motion/cdq/relationship_query.rb
@@ -3,6 +3,8 @@ module CDQ
 
   class CDQRelationshipQuery < CDQTargetedQuery
 
+    attr_reader :target_class
+
     def initialize(owner, name, set = nil, opts = {})
       @owner = owner ? WeakRef.new(owner) : nil
       @relationship_name = name
@@ -132,7 +134,7 @@ module CDQ
       end
 
       def method_missing(method, *args, &block)
-        if @__query__.respond_to?(method)
+        if @__query__.target_class.respond_to?(method) || @__query__.respond_to?(method)
           @__query__.send(method, *args, &block)
         else
           super

--- a/spec/cdq/relationship_query_spec.rb
+++ b/spec/cdq/relationship_query_spec.rb
@@ -53,6 +53,7 @@ module CDQ
 
     it "should be able to use named scopes" do
       cdq(@author).articles.all_published.array.should == [@article1, @article2, @article3]
+      @author.articles.all_published.array.should == [@article1, @article2, @article3]
     end
 
     it "can handle many-to-many correctly" do


### PR DESCRIPTION
issue: https://github.com/infinitered/cdq/issues/130

So after figuring out a workaround, I *finally* took a look at the specs and noticed this test
```
it "should be able to use named scopes" do
      cdq(@author).articles.all_published.array.should == [@article1, @article2, @article3]
end
```

While this can address the problem, I think it could get dirty. For example:
```
cdq(cdq(@author).articles.all_published.first).comments.positive.array
```
Instead of easily chaining, you have to cdq() wrap for each depth level.

I modified `CDQRelationshipQuery` slightly to fix this (not sure if it is a smart way to do it) and added a spec line.